### PR TITLE
The reason we use standaloneSetup because we want to do a unit test n…

### DIFF
--- a/src/test/java/warakorn/springframework/controllers/IndexControllerTest.java
+++ b/src/test/java/warakorn/springframework/controllers/IndexControllerTest.java
@@ -5,6 +5,8 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.ui.Model;
 import warakorn.springframework.domain.Recipe;
 import warakorn.springframework.services.RecipeService;
@@ -13,11 +15,11 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
 public class IndexControllerTest {
 
@@ -34,6 +36,19 @@ public class IndexControllerTest {
         MockitoAnnotations.initMocks(this);
 
         controller = new IndexController(recipeService);
+    }
+
+    @Test
+    public void testMockMVC() throws Exception {
+        /*
+        Use standaloneSetup because we want to do a unit test not all of test if we use a webAppContextSetup
+        it will bring all of context and it will no longer be a unit test
+         */
+        MockMvc mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+
+        mockMvc.perform(get("/"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("index"));
     }
 
     @Test

--- a/src/test/java/warakorn/springframework/services/RecipeServiceImplTest.java
+++ b/src/test/java/warakorn/springframework/services/RecipeServiceImplTest.java
@@ -24,7 +24,7 @@ public class RecipeServiceImplTest {
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.initMocks(this); //Initialize Mock tells mockito give me a mockRecipeRepository
 
         recipeService = new RecipeServiceImpl(recipeRepository);
     }


### PR DESCRIPTION
…ot all of test, if we use a webAppContextSetup it will bring all of context and it will no longer be a unit test